### PR TITLE
Update color to match default theme embed background

### DIFF
--- a/src/commands/wednesday.js
+++ b/src/commands/wednesday.js
@@ -6,7 +6,7 @@ module.exports = {
     execute: async (message, args) => {
         const today = new Date()
         const { channel } = message
-        const color = '0xffff00'
+        const color = '0x2e3136'
         const collection = [
             'https://i.imgur.com/1Ezcod1.png',
             'https://i.imgur.com/UHp7TTB.png',


### PR DESCRIPTION
Updates messageEmbed color to match the default theme background.

This might improve the look of the bot messages. You could also try `#36393f`

Link to relevant reddit thread... https://www.reddit.com/r/discordapp/comments/9l0l0m/the_new_colorless_embedded_messages_look_lit/

Fixes #6 